### PR TITLE
fix: support new file changed page path

### DIFF
--- a/src/chrome-addon/background.js
+++ b/src/chrome-addon/background.js
@@ -23,7 +23,7 @@ function addWhitespaceParam(url) {
 function isGitHubDiffUrl(url) {
   try {
     const urlObj = new URL(url);
-    return urlObj.hostname === 'github.com' && urlObj.pathname.includes('/files');
+    return urlObj.hostname === 'github.com' && (urlObj.pathname.includes('/files') || urlObj.pathname.includes('/changes'));
   } catch (e) {
     return false;
   }
@@ -67,7 +67,8 @@ chrome.webNavigation.onCommitted.addListener((details) => {
   });
 }, {
   url: [
-    { hostContains: 'github.com', pathContains: '/files' }
+    { hostContains: 'github.com', pathContains: '/files' },
+    { hostContains: 'github.com', pathContains: '/changes' }
   ]
 });
 

--- a/src/chrome-addon/content.js
+++ b/src/chrome-addon/content.js
@@ -27,7 +27,7 @@
   function isGitHubDiffUrl(url) {
     try {
       const urlObj = new URL(url);
-      return urlObj.hostname === 'github.com' && urlObj.pathname.includes('/files');
+      return urlObj.hostname === 'github.com' && (urlObj.pathname.includes('/files') || urlObj.pathname.includes('/changes'));
     } catch (e) {
       return false;
     }

--- a/src/firefox-addon/background.js
+++ b/src/firefox-addon/background.js
@@ -23,7 +23,7 @@ function addWhitespaceParam(url) {
 function isGitHubDiffUrl(url) {
   try {
     const urlObj = new URL(url);
-    return urlObj.hostname === 'github.com' && urlObj.pathname.includes('/files');
+    return urlObj.hostname === 'github.com' && (urlObj.pathname.includes('/files') || urlObj.pathname.includes('/changes'));
   } catch (e) {
     return false;
   }
@@ -67,7 +67,8 @@ browser.webNavigation.onCommitted.addListener((details) => {
   });
 }, {
   url: [
-    { hostContains: 'github.com', pathContains: '/files' }
+    { hostContains: 'github.com', pathContains: '/files' },
+    { hostContains: 'github.com', pathContains: '/changes' }
   ]
 });
 

--- a/src/firefox-addon/content.js
+++ b/src/firefox-addon/content.js
@@ -27,7 +27,7 @@
   function isGitHubDiffUrl(url) {
     try {
       const urlObj = new URL(url);
-      return urlObj.hostname === 'github.com' && urlObj.pathname.includes('/files');
+      return urlObj.hostname === 'github.com' && (urlObj.pathname.includes('/files') || urlObj.pathname.includes('/changes'));
     } catch (e) {
       return false;
     }


### PR DESCRIPTION
In the preview version of the new UI, the path has been changed from /files to /changes.

https://github.blog/changelog/2026-01-22-improved-pull-request-files-changed-page-on-by-default/

<img width="1929" height="741" alt="2026-02-27_19-19-59" src="https://github.com/user-attachments/assets/60c78f27-7c4b-490b-b7c5-525495ce92b6" />
